### PR TITLE
🌟[feat] 주식 현재가 / Top 30 거래대금 순위 API 구현

### DIFF
--- a/src/main/java/juby/invest/config/AppConfig.java
+++ b/src/main/java/juby/invest/config/AppConfig.java
@@ -8,7 +8,8 @@ import org.springframework.web.client.RestClient;
 @Configuration
 public class AppConfig {
 
-    @Value("${kis.base-url}") private String investUrl;
+    @Value("${kis.mock.base-url}") private String investUrl;
+    @Value("${kis.real.base-url}") private String realInvestUrl;
 
     @Bean
     public RestClient investRestClient(){
@@ -17,4 +18,10 @@ public class AppConfig {
                 .build();
     }
 
+    @Bean
+    public RestClient realInvestRestClient(){
+        return RestClient.builder()
+                .baseUrl(realInvestUrl)
+                .build();
+    }
 }

--- a/src/main/java/juby/invest/config/AppConfig.java
+++ b/src/main/java/juby/invest/config/AppConfig.java
@@ -8,13 +8,13 @@ import org.springframework.web.client.RestClient;
 @Configuration
 public class AppConfig {
 
-    @Value("${kis.mock.base-url}") private String investUrl;
+    @Value("${kis.mock.base-url}") private String mockInvestUrl;
     @Value("${kis.real.base-url}") private String realInvestUrl;
 
     @Bean
     public RestClient investRestClient(){
         return RestClient.builder()
-                .baseUrl(investUrl)
+                .baseUrl(mockInvestUrl)
                 .build();
     }
 

--- a/src/main/java/juby/invest/controller/MarketController.java
+++ b/src/main/java/juby/invest/controller/MarketController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import juby.invest.dto.CurrentPriceDto;
+import juby.invest.dto.TradingVolumeDto;
 import juby.invest.service.MarketService;
+import juby.invest.service.TradingVolumeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +15,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "시세 조회 API", description = "주식의 현재 정보를 조회한다.")
+import java.util.List;
+
+@Tag(name = "주식 조회 API", description = "주식의 현재 정보를 조회한다.")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -21,12 +25,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class MarketController {
 
     private final MarketService marketService;
+    private final TradingVolumeService tradingVolumeService;
 
     @Operation(summary = "주식 현재가 및 전일대비 조회", description = "종목 코드를 입력 받아 현재가와 전일대비를 반환한다.")
     @GetMapping("/price")
     public ResponseEntity<CurrentPriceDto.Output> getPrice(@Parameter(description = "종목 코드")
             @RequestParam String code){
         CurrentPriceDto.Output response = marketService.getCurrentPrice(code);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "주식 거래량 조회", description = "주식의 거래량 TOP 30 목록을 반환한다.")
+    @GetMapping("/volume-rank")
+    public ResponseEntity<List<TradingVolumeDto.Output>> getTradingVolume(){
+        List<TradingVolumeDto.Output> response = tradingVolumeService.getTradingVolume();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/juby/invest/controller/TokenController.java
+++ b/src/main/java/juby/invest/controller/TokenController.java
@@ -7,7 +7,6 @@ import juby.invest.service.TokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +23,7 @@ public class TokenController {
     @Operation(summary = "KIS AccessToken 발급", description = "한국투자증권 서버에 요청하여 Access Token을 발급받아 반환합니다.")
     @GetMapping
     public ResponseEntity<TokenDto.TokenResponse> getToken(){
-        TokenDto.TokenResponse response = tokenService.getAccessToken();
+        TokenDto.TokenResponse response = tokenService.getMockAccessToken();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/juby/invest/dto/TradingVolumeDto.java
+++ b/src/main/java/juby/invest/dto/TradingVolumeDto.java
@@ -1,0 +1,18 @@
+package juby.invest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record TradingVolumeDto(
+        @JsonProperty("rt_cd") String rtCd,
+        @JsonProperty("msg1") String message,
+        @JsonProperty("output") List<Output> outputList
+){
+    public record Output(
+            @JsonProperty("hts_kor_isnm") String stockName,
+            @JsonProperty("data_rank") String dataRank,
+            @JsonProperty("stck_prpr") String currentPrice,
+            @JsonProperty("avrg_tr_pbmn") String averageVolume
+    ){}
+}

--- a/src/main/java/juby/invest/service/MarketService.java
+++ b/src/main/java/juby/invest/service/MarketService.java
@@ -14,18 +14,18 @@ public class MarketService {
 
     @Value("${kis.mock.app-secret}") String appSecret;
     @Value("${kis.mock.app-key}") String appKey;
-    @Value("/uapi/domestic-stock/v1/quotations/inquire-price") String path; // 주식 시세 조회 엔드 API
+
     private final RestClient investRestClient;
     private final TokenService tokenService;
 
     public CurrentPriceDto.Output getCurrentPrice(String stockCode){
 
         // accessToken 발급 과정
-        String accessToken = tokenService.getAccessToken().accessToken();
+        String accessToken = tokenService.getMockAccessToken().accessToken();
 
         CurrentPriceDto response = investRestClient.get()
                 .uri(uriBuilder -> uriBuilder
-                        .path(path)
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-price")
                         .queryParam("FID_COND_MRKT_DIV_CODE", "J")
                         .queryParam("FID_INPUT_ISCD", stockCode) // 입력 종목 코드
                         .build())
@@ -41,6 +41,7 @@ public class MarketService {
             throw new RuntimeException("현재가 조회 실패");
         }
 
+        log.info("현재가 조회 성공: response.output 반환 {}", response.output());
         return new CurrentPriceDto.Output(response.output().currentPrice(), response.output().compareYesterday());
     }
 }

--- a/src/main/java/juby/invest/service/MarketService.java
+++ b/src/main/java/juby/invest/service/MarketService.java
@@ -14,7 +14,7 @@ public class MarketService {
 
     @Value("${kis.app-secret}") String appSecret;
     @Value("${kis.app-key}") String appKey;
-
+    @Value("/uapi/domestic-stock/v1/quotations/inquire-price") String path; // 주식 시세 조회 엔드 API
     private final RestClient investRestClient;
     private final TokenService tokenService;
 
@@ -25,7 +25,7 @@ public class MarketService {
 
         CurrentPriceDto response = investRestClient.get()
                 .uri(uriBuilder -> uriBuilder
-                        .path("/uapi/domestic-stock/v1/quotations/inquire-price")
+                        .path(path)
                         .queryParam("FID_COND_MRKT_DIV_CODE", "J")
                         .queryParam("FID_INPUT_ISCD", stockCode) // 입력 종목 코드
                         .build())

--- a/src/main/java/juby/invest/service/MarketService.java
+++ b/src/main/java/juby/invest/service/MarketService.java
@@ -12,8 +12,8 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class MarketService {
 
-    @Value("${kis.app-secret}") String appSecret;
-    @Value("${kis.app-key}") String appKey;
+    @Value("${kis.mock.app-secret}") String appSecret;
+    @Value("${kis.mock.app-key}") String appKey;
     @Value("/uapi/domestic-stock/v1/quotations/inquire-price") String path; // 주식 시세 조회 엔드 API
     private final RestClient investRestClient;
     private final TokenService tokenService;

--- a/src/main/java/juby/invest/service/TokenService.java
+++ b/src/main/java/juby/invest/service/TokenService.java
@@ -18,8 +18,8 @@ public class TokenService {
 
     private final RestClient investRestClient;
 
-    @Value("${kis.app-key}") private String appKey;
-    @Value("${kis.app-secret}") private String appSecret;
+    @Value("${kis.mock.app-key}") private String appKey;
+    @Value("${kis.mock.app-secret}") private String appSecret;
 
     // accessToken 캐싱을 위함.
     private String cachedToken;

--- a/src/main/java/juby/invest/service/TokenService.java
+++ b/src/main/java/juby/invest/service/TokenService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -17,26 +16,31 @@ import java.time.LocalDateTime;
 public class TokenService {
 
     private final RestClient investRestClient;
+    private final RestClient realInvestRestClient;
 
-    @Value("${kis.mock.app-key}") private String appKey;
-    @Value("${kis.mock.app-secret}") private String appSecret;
+    @Value("${kis.mock.app-key}") private String mockAppKey;
+    @Value("${kis.mock.app-secret}") private String mockAppSecret;
+    @Value("${kis.real.app-key}") private String realAppKey;
+    @Value("${kis.real.app-secret}") private String realAppSecret;
 
     // accessToken 캐싱을 위함.
-    private String cachedToken;
-    private LocalDateTime tokenExpirationTime;
+    private String mockCachedToken;
+    private String realCachedToken;
+    private LocalDateTime mockTokenExpirationTime;
+    private LocalDateTime realTokenExpirationTime;
 
-    public TokenDto.TokenResponse getAccessToken(){
+    public TokenDto.TokenResponse getMockAccessToken(){
 
         // 캐시된 accessToken이 존재하고 accessToken 만료 시간 전일 경우
-        if (cachedToken != null && tokenExpirationTime != null && LocalDateTime.now().isBefore(tokenExpirationTime)){
-            log.info("캐시된 토큰으로 조회");
-            int seconds = (int)Duration.between(LocalDateTime.now(), tokenExpirationTime).getSeconds();
-            return new TokenDto.TokenResponse(cachedToken, seconds);
+        if (mockCachedToken != null && mockTokenExpirationTime != null && LocalDateTime.now().isBefore(mockTokenExpirationTime)){
+            log.info("캐시된 mock토큰으로 조회");
+            int seconds = (int)Duration.between(LocalDateTime.now(), mockTokenExpirationTime).getSeconds();
+            return new TokenDto.TokenResponse(mockCachedToken, seconds);
         }
 
         // 캐시된 accessToken이 존재하지 않을 경우
-        log.info("새로운 토큰을 발급받음");
-        TokenDto.TokenRequest request = new TokenDto.TokenRequest("client_credentials", appKey, appSecret);
+        log.info("새로운 mock토큰을 발급받음");
+        TokenDto.TokenRequest request = new TokenDto.TokenRequest("client_credentials", mockAppKey, mockAppSecret);
 
         TokenDto.TokenResponse response = investRestClient.post()
                 .uri("/oauth2/tokenP")
@@ -49,8 +53,37 @@ public class TokenService {
             throw new RuntimeException("토큰 발급에 실패했습니다.");
         }
 
-        this.cachedToken = response.accessToken();
-        this.tokenExpirationTime = LocalDateTime.now().plusSeconds(response.expiresIn() - 600);
+        this.mockCachedToken = response.accessToken();
+        this.mockTokenExpirationTime = LocalDateTime.now().plusSeconds(response.expiresIn() - 600);
+        return response;
+    }
+
+    public TokenDto.TokenResponse getRealAccessToken(){
+
+        // 토큰이 있고, 만료되지 않았을 때
+        if (realCachedToken != null && realTokenExpirationTime != null&& LocalDateTime.now().isBefore(realTokenExpirationTime)){
+            log.info("캐시된 real토큰으로 조회");
+            int seconds = (int)Duration.between(LocalDateTime.now(), realTokenExpirationTime).getSeconds();
+            return new TokenDto.TokenResponse(realCachedToken, seconds);
+        }
+
+        // 토큰이 없거나 만료되었을 때
+        log.info("새로운 real토큰을 발급받음");
+        TokenDto.TokenRequest request = new TokenDto.TokenRequest("client_credentials", realAppKey, realAppSecret);
+        TokenDto.TokenResponse response = realInvestRestClient.post()
+                .uri("/oauth2/tokenP")
+                .body(request)
+                .retrieve()
+                .body(TokenDto.TokenResponse.class);
+
+        if (response == null || response.accessToken() == null){
+            log.info("실전 모의 투자 토큰 발급 실패");
+            throw new RuntimeException("실전 모의 투자 토큰 발급 실패");
+        }
+
+        this.realCachedToken = response.accessToken();
+        this.realTokenExpirationTime = LocalDateTime.now().plusSeconds(response.expiresIn() - 600);
+
         return response;
     }
 }

--- a/src/main/java/juby/invest/service/TradingVolumeService.java
+++ b/src/main/java/juby/invest/service/TradingVolumeService.java
@@ -1,0 +1,56 @@
+package juby.invest.service;
+
+import juby.invest.dto.TradingVolumeDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TradingVolumeService {
+
+    private final RestClient realInvestRestClient;
+    private final TokenService tokenService;
+
+    @Value("${kis.real.app-key}") String appKey;
+    @Value("${kis.real.app-secret}") String appSecret;
+
+    public List<TradingVolumeDto.Output> getTradingVolume(){
+        String accessToken = tokenService.getRealAccessToken().accessToken();
+
+        TradingVolumeDto response = realInvestRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/volume-rank")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_COND_SCR_DIV_CODE", "20171")
+                        .queryParam("FID_INPUT_ISCD", "0000")
+                        .queryParam("FID_BLNG_CLS_CODE", "3")
+                        .queryParam("FID_TRGT_CLS_CODE", "111111111")
+                        .queryParam("FID_TRGT_EXLS_CLS_CODE", "0000000000")
+                        .queryParam("FID_INPUT_PRICE_1", "10000")
+                        .queryParam("FID_INPUT_PRICE_2", "")
+                        .queryParam("FID_VOL_CNT", "")
+                        .queryParam("FID_INPUT_DATE_1", "")
+                        .build())
+                .header("authorization", "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHPST01710000")
+                .retrieve()
+                .body(TradingVolumeDto.class);
+
+        if (response == null || response.rtCd().equals("1")){
+            String errMsg = response != null ? response.message() : "응답이 NULL";
+            log.info("거래량 조회 실패: 사유: {}", errMsg);
+            throw new RuntimeException("거래량 조회를 실패하였습니다.");
+        }
+
+        log.info("거래량 조회 성공: response.outputList 반환 {}", response.outputList());
+        return response.outputList();
+    }
+}


### PR DESCRIPTION
### 🌟Related Issue
#1 KIS API 현재가/거래대금 조회 API 구현

### 📌Discription
KIS API를 활용하여 주식 종목코드를 파라미터로 받아, 해당 주식의 현재가를 조회하는 API 기능,
Top 30 거래대금 순위 조회 API를 구현하였습니다.

### 🔨 Tasks
- [x] Mock/Real accessToken 분리: 기존 mockAccessToken 뿐 아니라 realAccessToken도 받아와 세션에 저장.
- [x] 세션에 저장된 accessToken 조회: 받아온 accessToken에 대해 만료시간을 -10분으로 저장하여, 이미 토큰이 존재하거나 만료시간 전이면 세션에 담긴 토큰 반환. 아니면 새로 발급 요청
- [x] 현재가 조회: mockAccessToken으로 get 요청. 받아온 값을 currentPriceDto에 보관.
- [x] 거래대금 조회: realAccessToken으로 get 요청. 받아온 값을 tradingVolumeDto에 보관.