### PR TITLE
🌟[Feat] 3/12일 기준 시가총액 상위 100개 기업 DB INSERT 구현, 주식현재가 일자별 API 호출 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	// testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/juby/invest/config/AppConfig.java
+++ b/src/main/java/juby/invest/config/AppConfig.java
@@ -11,6 +11,7 @@ public class AppConfig {
     @Value("${kis.mock.base-url}") private String mockInvestUrl;
     @Value("${kis.real.base-url}") private String realInvestUrl;
 
+    // 모의 Domain
     @Bean
     public RestClient investRestClient(){
         return RestClient.builder()
@@ -18,6 +19,7 @@ public class AppConfig {
                 .build();
     }
 
+    // 실전 Domain
     @Bean
     public RestClient realInvestRestClient(){
         return RestClient.builder()

--- a/src/main/java/juby/invest/controller/MarketController.java
+++ b/src/main/java/juby/invest/controller/MarketController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import juby.invest.dto.CurrentPriceDto;
+import juby.invest.dto.DailyStockPriceDto;
 import juby.invest.dto.TradingVolumeDto;
+import juby.invest.service.DailyStockPriceService;
 import juby.invest.service.MarketService;
 import juby.invest.service.TradingVolumeService;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "주식 조회 API", description = "주식의 현재 정보를 조회한다.")
+@Tag(name = "주식 조회 API", description = "주식의 각종 정보를 조회한다.")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +28,7 @@ public class MarketController {
 
     private final MarketService marketService;
     private final TradingVolumeService tradingVolumeService;
+    private final DailyStockPriceService dailyStockPriceService;
 
     @Operation(summary = "주식 현재가 및 전일대비 증감 조회", description = "종목 코드를 입력 받아 현재가와 전일대비 증감액을 반환한다.")
     @GetMapping("/price")
@@ -40,5 +43,13 @@ public class MarketController {
     public ResponseEntity<List<TradingVolumeDto.Output>> getTradingVolume(){
         List<TradingVolumeDto.Output> response = tradingVolumeService.getTradingVolume();
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "주식현재가 일자별 조회", description = "종목의 30일 OHLCV정보를 조회한다.")
+    @GetMapping("/daily-stock")
+    public ResponseEntity<List<DailyStockPriceDto.Output>> getDailyStockPrice(@Parameter(description = "종목 코드")
+            @RequestParam String stockCode){
+        List<DailyStockPriceDto.Output> dailyStockPrice = dailyStockPriceService.getDailyStockPrice(stockCode);
+        return ResponseEntity.ok(dailyStockPrice);
     }
 }

--- a/src/main/java/juby/invest/domain/DailyPrice.java
+++ b/src/main/java/juby/invest/domain/DailyPrice.java
@@ -1,0 +1,52 @@
+package juby.invest.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "daily_price")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyPrice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_code", nullable = false)
+    private Stock stock;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "open_price", nullable = false)
+    private Integer openPrice;
+
+    @Column(name = "high_price", nullable = false)
+    private Integer highPrice;
+
+    @Column(name = "low_price", nullable = false)
+    private Integer lowPrice;
+
+    @Column(name = "close_price", nullable = false)
+    private Integer closePrice;
+
+    @Column(name = "volume", nullable = false)
+    private Integer volume;
+
+    @Builder
+    public DailyPrice(Stock stock, LocalDate date, Integer openPrice, Integer highPrice, Integer lowPrice, Integer closePrice, Integer volume) {
+        this.stock = stock;
+        this.date = date;
+        this.openPrice = openPrice;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
+        this.closePrice = closePrice;
+        this.volume = volume;
+    }
+}

--- a/src/main/java/juby/invest/domain/Stock.java
+++ b/src/main/java/juby/invest/domain/Stock.java
@@ -1,0 +1,27 @@
+package juby.invest.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "stock")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock {
+
+    @Id
+    @Column(name = "stock_code", length = 20)
+    private String stockCode;
+
+    @Column(name = "stock_name", nullable = false, length = 50)
+    private String stockName;
+
+    @Builder
+    public Stock(String stockCode, String stockName){
+        this.stockCode = stockCode;
+        this.stockName = stockName;
+    }
+}

--- a/src/main/java/juby/invest/dto/DailyStockPriceDto.java
+++ b/src/main/java/juby/invest/dto/DailyStockPriceDto.java
@@ -1,0 +1,20 @@
+package juby.invest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record DailyStockPriceDto(
+        @JsonProperty("rt_cd") String rtCd,
+        @JsonProperty("msg1") String message,
+        @JsonProperty("output") List<Output> output
+){
+    public record Output(
+        @JsonProperty("stck_bsop_date") String date,
+        @JsonProperty("stck_oprc") String openPrice,
+        @JsonProperty("stck_hgpr") String highPrice,
+        @JsonProperty("stck_lwpr") String lowPrice,
+        @JsonProperty("stck_clpr") String closePrice,
+        @JsonProperty("acml_vol") String volume
+    ){}
+}

--- a/src/main/java/juby/invest/initiate/StockLoader.java
+++ b/src/main/java/juby/invest/initiate/StockLoader.java
@@ -1,0 +1,141 @@
+package juby.invest.initiate;
+
+import jakarta.transaction.Transactional;
+import juby.invest.domain.Stock;
+import juby.invest.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+//@Component
+@RequiredArgsConstructor
+public class StockLoader {
+
+    private final StockRepository stockRepository;
+
+    /***
+     * 함수명: initStockData()
+     * 기능: 국내 시총 상위 100개 기업에 대해서 (종목코드, 종목번호)를 미리 DB에 저장하기 위한 Initial 작업이다. (완료)
+     *      DB에 INSERT가 완료되었기에, Component를 주석 처리해주었다.
+     *       추후 기업명 혹은 코드가 바뀌면 수정해주어야 한다.
+     */
+
+    @EventListener(ApplicationReadyEvent.class) // 서버가 켜지면 그 즉시 자동으로 실행된다.
+    @Transactional
+    public void initStockData(){
+        if (stockRepository.count() <100){
+            log.info("이미 국내 시총 100위 기업 저장 완료.");
+            return;
+        }
+
+        List<Stock> initialStocks = List.of(
+                Stock.builder().stockCode("005930").stockName("삼성전자").build(),
+                Stock.builder().stockCode("000660").stockName("SK하이닉스").build(),
+                Stock.builder().stockCode("005935").stockName("삼성전자우").build(),
+                Stock.builder().stockCode("005380").stockName("현대차").build(),
+                Stock.builder().stockCode("373220").stockName("LG에너지솔루션").build(),
+                Stock.builder().stockCode("012450").stockName("한화에어로스페이스").build(),
+                Stock.builder().stockCode("207940").stockName("삼성바이오로직스").build(),
+                Stock.builder().stockCode("402340").stockName("SK스퀘어").build(),
+                Stock.builder().stockCode("034020").stockName("두산에너빌리티").build(),
+                Stock.builder().stockCode("000270").stockName("기아").build(),
+                Stock.builder().stockCode("329180").stockName("HD현대중공업").build(),
+                Stock.builder().stockCode("105560").stockName("KB금융").build(),
+                Stock.builder().stockCode("068270").stockName("셀트리온").build(),
+                Stock.builder().stockCode("028260").stockName("삼성물산").build(),
+                Stock.builder().stockCode("055550").stockName("신한지주").build(),
+                Stock.builder().stockCode("032830").stockName("삼성생명").build(),
+                Stock.builder().stockCode("012330").stockName("현대모비스").build(),
+                Stock.builder().stockCode("042660").stockName("한화오션").build(),
+                Stock.builder().stockCode("006800").stockName("미래에셋증권").build(),
+                Stock.builder().stockCode("035420").stockName("NAVER").build(),
+                Stock.builder().stockCode("267260").stockName("HD현대일렉트릭").build(),
+                Stock.builder().stockCode("010130").stockName("고려아연").build(),
+                Stock.builder().stockCode("006400").stockName("삼성SDI").build(),
+                Stock.builder().stockCode("042700").stockName("한미반도체").build(),
+                Stock.builder().stockCode("086790").stockName("하나금융지주").build(),
+                Stock.builder().stockCode("015760").stockName("한국전력").build(),
+                Stock.builder().stockCode("009150").stockName("삼성전기").build(),
+                Stock.builder().stockCode("272210").stockName("한화시스템").build(),
+                Stock.builder().stockCode("009540").stockName("HD한국조선해양").build(),
+                Stock.builder().stockCode("005490").stockName("POSCO홀딩스").build(),
+                Stock.builder().stockCode("034730").stockName("SK").build(),
+                Stock.builder().stockCode("010140").stockName("삼성중공업").build(),
+                Stock.builder().stockCode("298040").stockName("효성중공업").build(),
+                Stock.builder().stockCode("316140").stockName("우리금융지주").build(),
+                Stock.builder().stockCode("035720").stockName("카카오").build(),
+                Stock.builder().stockCode("064350").stockName("현대로템").build(),
+                Stock.builder().stockCode("000810").stockName("삼성화재").build(),
+                Stock.builder().stockCode("051910").stockName("LG화학").build(),
+                Stock.builder().stockCode("010120").stockName("LS ELECTRIC").build(),
+                Stock.builder().stockCode("267250").stockName("HD현대").build(),
+                Stock.builder().stockCode("096770").stockName("SK이노베이션").build(),
+                Stock.builder().stockCode("138040").stockName("메리츠금융지주").build(),
+                Stock.builder().stockCode("011200").stockName("HMM").build(),
+                Stock.builder().stockCode("066570").stockName("LG전자").build(),
+                Stock.builder().stockCode("003670").stockName("포스코퓨처엠").build(),
+                Stock.builder().stockCode("024110").stockName("기업은행").build(),
+                Stock.builder().stockCode("033780").stockName("KT&G").build(),
+                Stock.builder().stockCode("086280").stockName("현대글로비스").build(),
+                Stock.builder().stockCode("069500").stockName("KODEX 200").build(),
+                Stock.builder().stockCode("000150").stockName("두산").build(),
+                Stock.builder().stockCode("047810").stockName("한국항공우주").build(),
+                Stock.builder().stockCode("000720").stockName("현대건설").build(),
+                Stock.builder().stockCode("079550").stockName("LIG넥스원").build(),
+                Stock.builder().stockCode("017670").stockName("SK텔레콤").build(),
+                Stock.builder().stockCode("030200").stockName("KT").build(),
+                Stock.builder().stockCode("352820").stockName("하이브").build(),
+                Stock.builder().stockCode("360750").stockName("TIGER 미국S&P500").build(),
+                Stock.builder().stockCode("003550").stockName("LG").build(),
+                Stock.builder().stockCode("047050").stockName("포스코인터내셔널").build(),
+                Stock.builder().stockCode("010950").stockName("S-Oil").build(),
+                Stock.builder().stockCode("0126Z0").stockName("삼성에피스홀딩스").build(),
+                Stock.builder().stockCode("005830").stockName("DB손해보험").build(),
+                Stock.builder().stockCode("018260").stockName("삼성에스디에스").build(),
+                Stock.builder().stockCode("071050").stockName("한국금융지주").build(),
+                Stock.builder().stockCode("039490").stockName("키움증권").build(),
+                Stock.builder().stockCode("323410").stockName("카카오뱅크").build(),
+                Stock.builder().stockCode("278470").stockName("에이피알").build(),
+                Stock.builder().stockCode("259960").stockName("크래프톤").build(),
+                Stock.builder().stockCode("005940").stockName("NH투자증권").build(),
+                Stock.builder().stockCode("307950").stockName("현대오토에버").build(),
+                Stock.builder().stockCode("000880").stockName("한화").build(),
+                Stock.builder().stockCode("005387").stockName("현대차2우B").build(),
+                Stock.builder().stockCode("003490").stockName("대한항공").build(),
+                Stock.builder().stockCode("009830").stockName("한화솔루션").build(),
+                Stock.builder().stockCode("007660").stockName("이수페타시스").build(),
+                Stock.builder().stockCode("016360").stockName("삼성증권").build(),
+                Stock.builder().stockCode("180640").stockName("한진칼").build(),
+                Stock.builder().stockCode("379800").stockName("KODEX 미국S&P500").build(),
+                Stock.builder().stockCode("377300").stockName("카카오페이").build(),
+                Stock.builder().stockCode("459580").stockName("KODEX CD금리액티브(합성)").build(),
+                Stock.builder().stockCode("133690").stockName("TIGER 미국나스닥100").build(),
+                Stock.builder().stockCode("000100").stockName("유한양행").build(),
+                Stock.builder().stockCode("326030").stockName("SK바이오팜").build(),
+                Stock.builder().stockCode("396500").stockName("TIGER 반도체TOP10").build(),
+                Stock.builder().stockCode("003230").stockName("삼양식품").build(),
+                Stock.builder().stockCode("006260").stockName("LS").build(),
+                Stock.builder().stockCode("090430").stockName("아모레퍼시픽").build(),
+                Stock.builder().stockCode("443060").stockName("HD현대마린솔루션").build(),
+                Stock.builder().stockCode("161390").stockName("한국타이어앤테크놀로지").build(),
+                Stock.builder().stockCode("229200").stockName("KODEX 코스닥150").build(),
+                Stock.builder().stockCode("488770").stockName("KODEX 머니마켓액티브").build(),
+                Stock.builder().stockCode("102110").stockName("TIGER 200").build(),
+                Stock.builder().stockCode("029780").stockName("삼성카드").build(),
+                Stock.builder().stockCode("128940").stockName("한미약품").build(),
+                Stock.builder().stockCode("032640").stockName("LG유플러스").build(),
+                Stock.builder().stockCode("267270").stockName("HD건설기계").build(),
+                Stock.builder().stockCode("064400").stockName("LG씨엔에스").build(),
+                Stock.builder().stockCode("005385").stockName("현대차우").build(),
+                Stock.builder().stockCode("028050").stockName("삼성E&A").build(),
+                Stock.builder().stockCode("052690").stockName("한전기술").build());
+
+        stockRepository.saveAll(initialStocks);
+        log.info("기본 주식 종목 {}개 INSERT 완료", initialStocks.size());
+    }
+}

--- a/src/main/java/juby/invest/repository/DailyPriceRepository.java
+++ b/src/main/java/juby/invest/repository/DailyPriceRepository.java
@@ -1,0 +1,9 @@
+package juby.invest.repository;
+
+import juby.invest.domain.DailyPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DailyPriceRepository extends JpaRepository<DailyPrice, Long> {
+}

--- a/src/main/java/juby/invest/repository/StockRepository.java
+++ b/src/main/java/juby/invest/repository/StockRepository.java
@@ -1,0 +1,11 @@
+package juby.invest.repository;
+
+import juby.invest.domain.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StockRepository extends JpaRepository<Stock, String> {
+
+    
+}

--- a/src/main/java/juby/invest/service/DailyStockPriceService.java
+++ b/src/main/java/juby/invest/service/DailyStockPriceService.java
@@ -1,0 +1,50 @@
+package juby.invest.service;
+
+import juby.invest.dto.DailyStockPriceDto;
+import juby.invest.dto.TokenDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyStockPriceService {
+
+    private final RestClient investRestClient;
+    private final TokenService tokenService;
+
+    @Value("${kis.mock.app-key}") String appKey;
+    @Value("${kis.mock.app-secret}") String appSecret;
+
+    public List<DailyStockPriceDto.Output> getDailyStockPrice(String stockCode){
+        String accessToken = tokenService.getMockAccessToken().accessToken();
+
+        DailyStockPriceDto response = investRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-daily-price")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .queryParam("FID_PERIOD_DIV_CODE", "D")
+                        .queryParam("FID_ORG_ADJ_PRC", 1)
+                        .build())
+                .header("authorization", "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST01010400")
+                .retrieve()
+                .body(DailyStockPriceDto.class);
+
+        if (response == null){
+            log.info("주식현재가 일자별 API 호출 실패");
+            throw new RuntimeException("주식현재가 일자별 API 호출 실패");
+        }
+
+        log.info("주식현재가 일자별 API 호출 성공");
+        return response.output();
+    }
+}


### PR DESCRIPTION
### 💡Related Issue
#5

### 🔨 Tasks
- [x] 3/12 기준의 시가총액 상위 100개 기업의 종목코드, 종목명을 DB에 INSERT 완료하였습니다. 
- [x] Stock, DailyPrice 엔티티와 레포지토리 계층을 구현하였습니다.
- [x] KSI API의 주식일자별 현재가를 호출하였습니다.

