### PR TITLE
🌟[Feat] 1년 치 종목 정보 (OHLVC) INSERT 로직 구현

### DIFF
--- a/src/main/java/juby/invest/controller/MarketController.java
+++ b/src/main/java/juby/invest/controller/MarketController.java
@@ -3,12 +3,8 @@ package juby.invest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import juby.invest.dto.CurrentPriceDto;
-import juby.invest.dto.DailyStockPriceDto;
-import juby.invest.dto.TradingVolumeDto;
-import juby.invest.service.DailyStockPriceService;
-import juby.invest.service.MarketService;
-import juby.invest.service.TradingVolumeService;
+import juby.invest.dto.*;
+import juby.invest.service.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +25,8 @@ public class MarketController {
     private final MarketService marketService;
     private final TradingVolumeService tradingVolumeService;
     private final DailyStockPriceService dailyStockPriceService;
+    private final PeriodStockPriceService periodStockPriceService;
+    private final CheckHolidayService checkHolidayService;
 
     @Operation(summary = "주식 현재가 및 전일대비 증감 조회", description = "종목 코드를 입력 받아 현재가와 전일대비 증감액을 반환한다.")
     @GetMapping("/price")
@@ -51,5 +49,24 @@ public class MarketController {
             @RequestParam String stockCode){
         List<DailyStockPriceDto.Output> dailyStockPrice = dailyStockPriceService.getDailyStockPrice(stockCode);
         return ResponseEntity.ok(dailyStockPrice);
+    }
+
+    @Operation(summary = "국내주식기간별시세조회API", description = "해당 종목의 기간별(최대 100개) 시세를 조회한다.")
+    @GetMapping("/daily_itemchartprice")
+    public ResponseEntity<List<PeriodStockPriceDto.Output>> getPeriodStockPrice(
+            @Parameter(description = "종목코드(005930)") @RequestParam("stockcode") String stockCode,
+            @Parameter(description = "시작날짜(20250303)") @RequestParam("startdate") String startDate,
+            @Parameter(description = "종료날짜(20250310") @RequestParam("enddate") String endDate){
+        List<PeriodStockPriceDto.Output> periodStockPrice = periodStockPriceService.getPeriodStockPrice(stockCode, startDate, endDate);
+        return ResponseEntity.ok(periodStockPrice);
+    }
+
+    @Operation(summary = "국내휴장일조회API", description = "영업일,거래일 여부ㄹ를 조회한다.")
+    @GetMapping("/holiday")
+    public ResponseEntity<List<HolidayDto.Output>> checkHolidayList(
+            @Parameter(description = "기준일자") @RequestParam("basedate") String baseDate
+    ){
+        List<HolidayDto.Output> holidayList = checkHolidayService.getHolidayList(baseDate);
+        return ResponseEntity.ok(holidayList);
     }
 }

--- a/src/main/java/juby/invest/domain/DailyPrice.java
+++ b/src/main/java/juby/invest/domain/DailyPrice.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @Entity
+@Getter
 @Table(name = "daily_price")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DailyPrice {

--- a/src/main/java/juby/invest/dto/HolidayDto.java
+++ b/src/main/java/juby/invest/dto/HolidayDto.java
@@ -1,0 +1,17 @@
+package juby.invest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record HolidayDto(
+        @JsonProperty("rt_cd") String rtCd,
+        @JsonProperty("msg1") String message,
+        @JsonProperty("output") List<Output> output
+){
+    public record Output(
+            @JsonProperty("bass_dt") String baseDate,
+            @JsonProperty("bzdy_yn") String openDay,
+            @JsonProperty("tr_day_yn") String tradeDay
+    ){}
+}

--- a/src/main/java/juby/invest/dto/PeriodStockPriceDto.java
+++ b/src/main/java/juby/invest/dto/PeriodStockPriceDto.java
@@ -1,0 +1,19 @@
+package juby.invest.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record PeriodStockPriceDto(
+        @JsonProperty("rt_cd") String rtCd,
+        @JsonProperty("msg1") String message,
+        @JsonProperty("output2") List<Output> output
+){
+    public record Output(
+        @JsonProperty("stck_bsop_date") String date,
+        @JsonProperty("stck_clpr") String closePrice,
+        @JsonProperty("stck_oprc") String openPrice,
+        @JsonProperty("stck_hgpr") String highPrice,
+        @JsonProperty("stck_lwpr") String lowPrice,
+        @JsonProperty("acml_vol") String volume){}
+}

--- a/src/main/java/juby/invest/initiate/Days30StockPriceLoaderService.java
+++ b/src/main/java/juby/invest/initiate/Days30StockPriceLoaderService.java
@@ -1,0 +1,88 @@
+package juby.invest.initiate;
+
+import jakarta.transaction.Transactional;
+import juby.invest.domain.DailyPrice;
+import juby.invest.domain.Stock;
+import juby.invest.dto.DailyStockPriceDto;
+import juby.invest.repository.DailyPriceRepository;
+import juby.invest.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class Days30StockPriceLoaderService {
+
+    private final RestClient investRestClient;
+    private final StockRepository stockRepository;
+    private final DailyPriceRepository dailyPriceRepository;
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Value("${kis.mock.app-key}") String appKey;
+    @Value("${kis.mock.app-secret}") String appSecret;
+
+    /***
+     * 함수 기능: 주식일자별 현재가 API(30일) 호출한다.
+     */
+    private List<DailyStockPriceDto.Output> getDailyStockPrice(String stockCode, String accessToken){
+
+        DailyStockPriceDto response = investRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-daily-price")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .queryParam("FID_PERIOD_DIV_CODE", "D")
+                        .queryParam("FID_ORG_ADJ_PRC", "1")
+                        .build())
+                .header("content-type", "application/json; charset=utf-8")
+                .header("authorization", "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST01010400")
+                .retrieve()
+                .body(DailyStockPriceDto.class);
+
+        if (response != null && response.rtCd().equals("0")){
+            log.info("API 호출 성공");
+        }
+        else{
+            log.error("API 호출 실패 : {}", response == null ? "null" : response.message());
+        }
+
+        return response.output();
+    }
+
+    /***
+     * 함수: 단일종목의 30일 주식 정보들 받아와, DB에 저장한다.
+     * @param stockCode 주식코드 6자리
+     */
+    @Transactional
+    public void saveDailyStockPrice(String stockCode, String accessToken) {
+
+        Stock stock = stockRepository.findById(stockCode)
+                .orElseThrow(() -> new RuntimeException("주식을 찾을 수 없습니다."));
+
+        List<DailyStockPriceDto.Output> dailyStockPrice = getDailyStockPrice(stockCode, accessToken);
+
+        List<DailyPrice> list = dailyStockPrice.stream().map(
+                o -> DailyPrice.builder()
+                        .stock(stock)
+                        .date(LocalDate.parse(o.date(), formatter))
+                        .openPrice(Integer.parseInt(o.openPrice()))
+                        .highPrice(Integer.parseInt(o.highPrice()))
+                        .lowPrice(Integer.parseInt(o.lowPrice()))
+                        .closePrice(Integer.parseInt(o.closePrice()))
+                        .volume(Integer.parseInt(o.volume()))
+                        .build()).toList();
+
+        dailyPriceRepository.saveAll(list);
+        log.info("종목 저장 완료: {}", stockCode);
+    }
+}

--- a/src/main/java/juby/invest/initiate/KsiApiClient.java
+++ b/src/main/java/juby/invest/initiate/KsiApiClient.java
@@ -1,0 +1,59 @@
+package juby.invest.initiate;
+
+import juby.invest.dto.PeriodStockPriceDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KsiApiClient {
+
+    private final RestClient investRestClient;
+
+    @Value("${kis.mock.app-key}") String appKey;
+    @Value("${kis.mock.app-secret}") String appSecret;
+
+    /***
+     * 함수 기능: 국내주식기간별시세 API 호출/응답으로 받은 Output List를 savePeriodStockPrice()에 넘겨준다.
+     * @param stockCode 주식코드(6자리)
+     * @param startDate 조회시작날짜
+     * @param endDate 조회마지막날짜
+     * @return List<PeriodStockPriceDto.Output> 해당 주식 코드의 일자별 OHLVC가 담긴다.
+     */
+    public List<PeriodStockPriceDto.Output> getPeriodStockPrice(String stockCode, String startDate, String endDate, String accessToken){
+
+        PeriodStockPriceDto response = investRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .queryParam("FID_INPUT_DATE_1", startDate)
+                        .queryParam("FID_INPUT_DATE_2", endDate)
+                        .queryParam("FID_PERIOD_DIV_CODE", "D")
+                        .queryParam("FID_ORG_ADJ_PRC", "0")
+                        .build())
+                .header("content-type", "application/json; charset=utf-8")
+                .header("authorization", "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST03010100")
+                .retrieve()
+                .body(PeriodStockPriceDto.class);
+
+        if (response != null && response.rtCd().equals("0")){
+            log.info("국내주식기간별시세 API 출력 정상");
+        }
+        else {
+            log.info("국내주식기간별시세 API 출력 오류 {}", response == null ? "null" : response.message());
+            throw new RuntimeException("국내주식기간별시세 API 출력 오류");
+        }
+
+        return response.output();
+    }
+}

--- a/src/main/java/juby/invest/initiate/PeriodStockPriceLoaderService.java
+++ b/src/main/java/juby/invest/initiate/PeriodStockPriceLoaderService.java
@@ -1,0 +1,60 @@
+package juby.invest.initiate;
+
+import jakarta.transaction.Transactional;
+import juby.invest.domain.DailyPrice;
+import juby.invest.domain.Stock;
+import juby.invest.dto.PeriodStockPriceDto;
+import juby.invest.repository.DailyPriceRepository;
+import juby.invest.repository.StockRepository;
+import juby.invest.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import javax.swing.text.DateFormatter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PeriodStockPriceLoaderService {
+
+    private final StockRepository stockRepository;
+    private final DailyPriceRepository dailyPriceRepository;
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    /***
+     * 함수 기능: 종목의 날짜별 데이터를 DB에 저장하는 함수
+     * @param stockCode 주식 코드 (6자리)
+     * @param outputList API 응답 리스트 (날짜별로 존재)
+     */
+    @Transactional
+    public void savePeriodStockPrice(String stockCode, List<PeriodStockPriceDto.Output> outputList){
+        Stock stock = stockRepository.findById(stockCode)
+                .orElseThrow(() -> new RuntimeException("주식을 찾을 수 없습니다."));
+
+        // 이미 DB에 값이 저장되어 있다면 return;
+//        if (dailyPriceRepository.existsByStockAndDate(stock, LocalDate.of(2025,2,3))){
+//            return;
+//        }
+
+        List<DailyPrice> list = outputList.stream().map(
+                o -> DailyPrice.builder()
+                        .stock(stock)
+                        .date(LocalDate.parse(o.date(), formatter))
+                        .openPrice(Integer.parseInt(o.openPrice()))
+                        .highPrice(Integer.parseInt(o.highPrice()))
+                        .lowPrice(Integer.parseInt(o.lowPrice()))
+                        .closePrice(Integer.parseInt(o.closePrice()))
+                        .volume(Integer.parseInt(o.volume()))
+                        .build()).toList();
+
+        dailyPriceRepository.saveAll(list);
+        log.info("종목 저장 완료 {}", stockCode);
+    }
+}

--- a/src/main/java/juby/invest/initiate/StockPriceLoader.java
+++ b/src/main/java/juby/invest/initiate/StockPriceLoader.java
@@ -1,0 +1,67 @@
+package juby.invest.initiate;
+
+import juby.invest.dto.PeriodStockPriceDto;
+import juby.invest.repository.StockRepository;
+import juby.invest.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockPriceLoader {
+
+    private final StockRepository stockRepository;
+    private final Days30StockPriceLoaderService days30StockPriceLoaderService;
+    private final KsiApiClient ksiApiClient;
+    private final PeriodStockPriceLoaderService periodStockPriceLoaderService;
+    private final TokenService tokenService ;
+
+    /***
+     * 함수 기능: top 100 종목의 리스트를 가져와, 각 종목에 대한 정보(30일)를 받아온다. (initate용)
+     */
+    //@EventListener(ApplicationReadyEvent.class)
+    public void getListOfTop100StockCodes(){
+        List<String> stockCodesList = stockRepository.findAllStockCodes();
+
+        // mockAccessToken 가져오기 호출
+        String accessToken = tokenService.getMockAccessToken().accessToken();
+
+        for (String stockCode : stockCodesList){
+            try {
+                days30StockPriceLoaderService.saveDailyStockPrice(stockCode, accessToken);
+                Thread.sleep(1200); // API 제한 준수
+            } catch (Exception e) {
+                log.error("종목 가져오기 실패: {}", e.getMessage());
+            }
+        }
+    }
+
+    /***
+     * 함수 기능: top100개 종목의 기간별 정보들을 조회하여 DB에 저장한다.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void getListOfTop100StockCodesAndPeriod(){
+        List<String> stockCodesList = stockRepository.findAllStockCodes();
+
+        String accessToken = tokenService.getMockAccessToken().accessToken();
+
+        for (String stockCode : stockCodesList){
+            try {
+                List<PeriodStockPriceDto.Output> outputList = ksiApiClient.getPeriodStockPrice(stockCode, "20260101", "20260126", accessToken);
+                periodStockPriceLoaderService.savePeriodStockPrice(stockCode, outputList);
+                Thread.sleep(1200);
+            } catch (Exception e){
+                log.error("종목 가져오기 실패 : {}", e.getMessage());
+            }
+        }
+        log.info("모든 종목 INSERT 완료");
+    }
+}

--- a/src/main/java/juby/invest/repository/DailyPriceRepository.java
+++ b/src/main/java/juby/invest/repository/DailyPriceRepository.java
@@ -1,9 +1,15 @@
 package juby.invest.repository;
 
 import juby.invest.domain.DailyPrice;
+import juby.invest.domain.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+
 @Repository
 public interface DailyPriceRepository extends JpaRepository<DailyPrice, Long> {
+    double findByDateBefore(LocalDate dateBefore);
+
+    boolean existsByStockAndDate(Stock stock,LocalDate date);
 }

--- a/src/main/java/juby/invest/repository/StockRepository.java
+++ b/src/main/java/juby/invest/repository/StockRepository.java
@@ -2,10 +2,14 @@ package juby.invest.repository;
 
 import juby.invest.domain.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, String> {
 
-    
+    @Query("select s.stockCode from Stock s")
+    List<String> findAllStockCodes();
 }

--- a/src/main/java/juby/invest/service/CheckHolidayService.java
+++ b/src/main/java/juby/invest/service/CheckHolidayService.java
@@ -1,0 +1,52 @@
+package juby.invest.service;
+
+import juby.invest.dto.HolidayDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CheckHolidayService {
+
+    @Value("${kis.real.app-key}") String appKey;
+    @Value("${kis.real.app-secret}") String appSecret;
+
+    private final RestClient realInvestRestClient;
+    private final TokenService tokenService;
+
+    public List<HolidayDto.Output> getHolidayList(String baseDate){
+
+        String accessToken = tokenService.getRealAccessToken().accessToken();
+
+        HolidayDto response = realInvestRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/chk-holiday")
+                        .queryParam("BASS_DT", baseDate)
+                        .queryParam("CTX_AREA_NK", "")
+                        .queryParam("CTX_AREA_FK", "")
+                        .build())
+                .header("content-type", "application/json; charset=utf-8")
+                .header("authorization", "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "CTCA0903R")
+                .retrieve()
+                .body(HolidayDto.class);
+
+        if (response != null && response.rtCd().equals("0")){
+            log.info("국내휴장일조회 API 호출 성공");
+        }
+        else {
+            log.info("국내휴장일조회 API 호출 실패 {}", response == null ? "null" : response.message());
+            throw new RuntimeException("국내휴장일조회 API 호출 실패");
+        }
+
+        return response.output();
+    }
+}

--- a/src/main/java/juby/invest/service/PeriodStockPriceService.java
+++ b/src/main/java/juby/invest/service/PeriodStockPriceService.java
@@ -1,6 +1,6 @@
 package juby.invest.service;
 
-import juby.invest.dto.DailyStockPriceDto;
+import juby.invest.dto.PeriodStockPriceDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,7 +12,7 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DailyStockPriceService {
+public class PeriodStockPriceService {
 
     private final RestClient investRestClient;
     private final TokenService tokenService;
@@ -20,30 +20,34 @@ public class DailyStockPriceService {
     @Value("${kis.mock.app-key}") String appKey;
     @Value("${kis.mock.app-secret}") String appSecret;
 
-    public List<DailyStockPriceDto.Output> getDailyStockPrice(String stockCode){
+    public List<PeriodStockPriceDto.Output> getPeriodStockPrice(String stockCode, String startDate, String endDate){
+
         String accessToken = tokenService.getMockAccessToken().accessToken();
 
-        DailyStockPriceDto response = investRestClient.get()
+        PeriodStockPriceDto response = investRestClient.get()
                 .uri(uriBuilder -> uriBuilder
-                        .path("/uapi/domestic-stock/v1/quotations/inquire-daily-price")
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice")
                         .queryParam("FID_COND_MRKT_DIV_CODE", "J")
                         .queryParam("FID_INPUT_ISCD", stockCode)
+                        .queryParam("FID_INPUT_DATE_1", startDate)
+                        .queryParam("FID_INPUT_DATE_2", endDate)
                         .queryParam("FID_PERIOD_DIV_CODE", "D")
-                        .queryParam("FID_ORG_ADJ_PRC", 1)
+                        .queryParam("FID_ORG_ADJ_PRC", "0")
                         .build())
+                .header("content-type", "application/json; charset=utf-8")
                 .header("authorization", "Bearer " + accessToken)
                 .header("appkey", appKey)
                 .header("appsecret", appSecret)
-                .header("tr_id", "FHKST01010400")
+                .header("tr_id", "FHKST03010100")
                 .retrieve()
-                .body(DailyStockPriceDto.class);
+                .body(PeriodStockPriceDto.class);
 
-        if (response == null){
-            log.info("주식현재가 일자별 API 호출 실패");
-            throw new RuntimeException("주식현재가 일자별 API 호출 실패");
+        if (response != null && response.rtCd().equals("0")){
+            log.info("국내주식기간별시세조회API 호출성공");
         }
-
-        log.info("주식현재가 일자별 API 호출 성공");
+        else {
+            log.error("국내주식기간별시세조회API 호출실패: {}", response == null ? "호출 오류" : response.message());
+        }
         return response.output();
     }
 }


### PR DESCRIPTION
### 🌟Related Issue
#5 

### 📌Discription
top 100개 종목의 1년 치 OHLVC 정보를 DB에 넣어주었습니다. `@EventListener`를 통해 애플리케이션 시작 시 동작하도록 만들었습니다.

### 🔨Tasks
- [ ] DTO 생성: 국내주식기간별시세조회API 호출 응답 값을 담을 PeriodStockPriceDto 생성
- [ ] API 요청: KsiApiClient를 통해 API 호출
- [ ] DB 저장: 받은 응답을 `saveAll()`를 통해 INSERT