### PR TITLE
🌟Feature/10: DB에서 조회한 DailyPrice 리스트를 ta4j의 Barseries로 변환하는 함수 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// ta4j 라이브러리
-	implementation 'org.ta4j:ta4j-core:0.17'
+	implementation 'org.ta4j:ta4j-core:0.22.3'
 }
 
 test {

--- a/src/main/java/juby/invest/repository/DailyPriceRepository.java
+++ b/src/main/java/juby/invest/repository/DailyPriceRepository.java
@@ -3,11 +3,16 @@ package juby.invest.repository;
 import juby.invest.domain.DailyPrice;
 import juby.invest.domain.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface DailyPriceRepository extends JpaRepository<DailyPrice, Long> {
     boolean existsByStock(Stock stock);
+
+    List<DailyPrice> findByStockStockCodeOrderByDateAsc(String stockCode);
 }

--- a/src/main/java/juby/invest/ta4j/controller/BacktestController.java
+++ b/src/main/java/juby/invest/ta4j/controller/BacktestController.java
@@ -1,0 +1,21 @@
+package juby.invest.ta4j.controller;
+
+import juby.invest.ta4j.service.BacktestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/backtest")
+@RequiredArgsConstructor
+public class BacktestController {
+
+    private final BacktestService backtestService;
+
+    @GetMapping("/convert")
+    public String convert(){
+        backtestService.runStrategy("005930");
+        return "Success";
+    }
+}

--- a/src/main/java/juby/invest/ta4j/converter/BarSeriesConverter.java
+++ b/src/main/java/juby/invest/ta4j/converter/BarSeriesConverter.java
@@ -1,0 +1,54 @@
+package juby.invest.ta4j.converter;
+
+import juby.invest.domain.DailyPrice;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+public class BarSeriesConverter {
+
+    /***
+     * 기능: List<DailyPrice> -> BarSeries로 변환
+     * @param dailyPriceList 특정 종목의 각 날짜의 OHLVC 데이터
+     * @param stockCode 종목 코드 (ex: 005930)
+     * @return BarSeries
+     */
+    public BarSeries convert(List<DailyPrice> dailyPriceList, String stockCode){
+
+        BarSeries series = new BaseBarSeriesBuilder().withName(stockCode).build();
+
+        ZoneId kstZone = ZoneId.of("Asia/Seoul");
+
+        try {
+            for (DailyPrice dailyPrice : dailyPriceList) {
+                Instant endTime = Instant.from(dailyPrice.getDate().atTime(15, 30).atZone(kstZone));
+
+                series.addBar(series.barBuilder()
+                        .timePeriod(Duration.ofDays(1))
+                        .endTime(endTime)
+                        .openPrice(dailyPrice.getOpenPrice())
+                        .highPrice(dailyPrice.getHighPrice())
+                        .lowPrice(dailyPrice.getLowPrice())
+                        .closePrice(dailyPrice.getClosePrice())
+                        .volume(dailyPrice.getVolume())
+                        .build());
+            }
+            log.info("BarSeries: {}", series.getFirstBar());
+
+        } catch (Exception e){
+            throw new RuntimeException("BarSeries 변환 에러 발생." + e.getMessage());
+        }
+
+        return series;
+    }
+}

--- a/src/main/java/juby/invest/ta4j/service/BacktestService.java
+++ b/src/main/java/juby/invest/ta4j/service/BacktestService.java
@@ -1,0 +1,31 @@
+package juby.invest.ta4j.service;
+
+import jakarta.transaction.Transactional;
+import juby.invest.domain.DailyPrice;
+import juby.invest.repository.DailyPriceRepository;
+import juby.invest.ta4j.converter.BarSeriesConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.ta4j.core.BarSeries;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BacktestService {
+
+    private final BarSeriesConverter barSeriesConverter;
+    private final DailyPriceRepository dailyPriceRepository;
+
+    @Transactional
+    public BarSeries runStrategy(String stockCode){
+
+        List<DailyPrice> dailyPriceList = dailyPriceRepository.findByStockStockCodeOrderByDateAsc(stockCode);
+        BarSeries series = barSeriesConverter.convert(dailyPriceList, stockCode);
+
+        log.info("변환된 Bar 개수: {}", series.getBarCount());
+        return series;
+    }
+}

--- a/src/test/java/juby/invest/ta4j/service/BacktestServiceTest.java
+++ b/src/test/java/juby/invest/ta4j/service/BacktestServiceTest.java
@@ -1,0 +1,67 @@
+package juby.invest.ta4j.service;
+
+import jakarta.transaction.Transactional;
+import juby.invest.domain.DailyPrice;
+import juby.invest.domain.Stock;
+import juby.invest.repository.DailyPriceRepository;
+import juby.invest.repository.StockRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.ta4j.core.BarSeries;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class BacktestServiceTest {
+
+    @Autowired private BacktestService backtestService;
+    @Autowired private DailyPriceRepository dailyPriceRepository;
+    @Autowired private StockRepository stockRepository;
+
+    @Test
+    @DisplayName("DB 데이터가 BarSeries로 정확히 변환되는지 확인")
+    void convert(){
+        // given
+        String stockCode = "005930";
+        saveDummyData(stockCode);
+
+        // when
+        BarSeries series = backtestService.runStrategy(stockCode);
+
+        // then
+        Assertions.assertThat(series).isNotNull();
+    }
+
+    private void saveDummyData(String stockCode) {
+        // 1. Stock 마스터 데이터 저장 (DailyPrice가 참조해야 하므로)
+        Stock stock = Stock.builder()
+                .stockCode(stockCode)
+                .stockName("삼성전자")
+                .build();
+        stockRepository.save(stock); // Repository 주입 필요
+
+        // 2. 1년치까지는 아니더라도 변환 로직 확인을 위한 데이터 2~3개 저장
+        DailyPrice day1 = DailyPrice.builder()
+                .stock(stock)
+                .date(LocalDate.of(2026, 3, 1))
+                .openPrice(50000).highPrice(51000).lowPrice(49000).closePrice(50500)
+                .volume(1000000)
+                .build();
+
+        DailyPrice day2 = DailyPrice.builder()
+                .stock(stock)
+                .date(LocalDate.of(2026, 3, 2))
+                .openPrice(50500).highPrice(52000).lowPrice(50000).closePrice(51500)
+                .volume(1200000)
+                .build();
+
+        dailyPriceRepository.saveAll(List.of(day1, day2));
+    }
+}


### PR DESCRIPTION
### 💡Related Issue
#10 

### 🔨 Tasks
- [x] ta4j 라이브러리 최신화: 기존 0.17 버전을 0.22.3 버전으로 최신화
- [x] 객체 변환: DB에서 '005930' 종목 코드의 DailyPrice 리스트를 ta4j의 BarSeries로 변환