### PR TITLE
🌟Feature/16: OAuth2.0 기반 소셜로그인을 통해 받아온 회원 정보를 DB에 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	 testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/src/main/java/juby/invest/MainController.java
+++ b/src/main/java/juby/invest/MainController.java
@@ -1,0 +1,13 @@
+package juby.invest;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    public String home(){
+        return "index";
+    }
+}

--- a/src/main/java/juby/invest/config/SecurityConfig.java
+++ b/src/main/java/juby/invest/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package juby.invest.config;
 
+import juby.invest.member.service.CustomOAuth2MemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -10,8 +12,10 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final CustomOAuth2MemberService customOAuth2MemberService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,14 +30,18 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable);
 
         http
-                .oauth2Login(Customizer.withDefaults());
+                .oauth2Login((oauth2) -> oauth2
+                        .loginPage("/")
+                        .defaultSuccessUrl("/member/successLogin")
+                        .failureUrl("/member/failureLogin")
+                        .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
+                                .userService(customOAuth2MemberService)));
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**", "/backtest/**").permitAll()
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/backtest/**", "/error/**").permitAll()
                         .anyRequest().authenticated());
 
         return http.build();
     }
-
 }

--- a/src/main/java/juby/invest/member/dto/GoogleResponse.java
+++ b/src/main/java/juby/invest/member/dto/GoogleResponse.java
@@ -1,0 +1,44 @@
+package juby.invest.member.dto;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class GoogleResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return attribute.get("picture").toString();
+    }
+
+    @Override
+    public String getBirthday() {
+        return "null";
+    }
+}

--- a/src/main/java/juby/invest/member/dto/NaverResponse.java
+++ b/src/main/java/juby/invest/member/dto/NaverResponse.java
@@ -1,0 +1,43 @@
+package juby.invest.member.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return attribute.get("profile_image").toString();
+    }
+
+    @Override
+    public String getBirthday() {
+        return attribute.get("birthday").toString();
+    }
+}

--- a/src/main/java/juby/invest/member/dto/OAuth2Response.java
+++ b/src/main/java/juby/invest/member/dto/OAuth2Response.java
@@ -1,0 +1,15 @@
+package juby.invest.member.dto;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public interface OAuth2Response {
+    String getProvider(); // ex) google, naver, kakao
+    String getProviderId(); // google이 Resource Owner에게 부여한 고유 회원 번호
+    String getEmail(); // 사용자 이메일
+    String getName(); // 사용자 이름
+    String getProfileUrl();
+    String getBirthday();
+}

--- a/src/main/java/juby/invest/member/entity/Member.java
+++ b/src/main/java/juby/invest/member/entity/Member.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import juby.invest.member.enums.InvestPersonality;
 import juby.invest.member.enums.Role;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -22,24 +23,33 @@ public class Member {
     private Long id;
 
     @Column(name = "email")
-    @NotNull
     private String email;
 
     @Column(name = "nickname")
-    @NotNull
     private String nickName;
 
     @Column(name = "profile_img")
-    @NotNull
     private String profileImg;
 
     @Column(name = "birth")
-    @NotNull
-    private LocalDate birth;
+    private String birth;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "invest_personality")
-    private Enum<InvestPersonality> investPersonality;
+    private InvestPersonality investPersonality;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "role")
-    private Enum<Role> role;
+    private Role role;
+
+    @Builder
+
+    public Member(String email, String nickName, String profileImg, String birth, Role role) {
+        this.email = email;
+        this.nickName = nickName;
+        this.profileImg = profileImg;
+        this.birth = birth;
+        this.investPersonality = null;
+        this.role = role;
+    }
 }

--- a/src/main/java/juby/invest/member/entity/SocialAccount.java
+++ b/src/main/java/juby/invest/member/entity/SocialAccount.java
@@ -2,6 +2,7 @@ package juby.invest.member.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +25,11 @@ public class SocialAccount {
 
     @Column(name = "provider_id")
     private String provider_id;
+
+    @Builder
+    public SocialAccount(Member member, String provider, String provider_id) {
+        this.member = member;
+        this.provider = provider;
+        this.provider_id = provider_id;
+    }
 }

--- a/src/main/java/juby/invest/member/repository/MemberRepository.java
+++ b/src/main/java/juby/invest/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package juby.invest.member.repository;
+
+import juby.invest.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findByEmail(String email);
+}

--- a/src/main/java/juby/invest/member/repository/SocialAccountRepository.java
+++ b/src/main/java/juby/invest/member/repository/SocialAccountRepository.java
@@ -1,0 +1,12 @@
+package juby.invest.member.repository;
+
+import juby.invest.member.entity.Member;
+import juby.invest.member.entity.SocialAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+    boolean existsByMemberAndProvider(Member member, String provider);
+}
+

--- a/src/main/java/juby/invest/member/service/CustomOAuth2MemberService.java
+++ b/src/main/java/juby/invest/member/service/CustomOAuth2MemberService.java
@@ -1,0 +1,92 @@
+package juby.invest.member.service;
+
+import jakarta.transaction.Transactional;
+import juby.invest.member.dto.GoogleResponse;
+import juby.invest.member.dto.NaverResponse;
+import juby.invest.member.dto.OAuth2Response;
+import juby.invest.member.entity.Member;
+import juby.invest.member.entity.SocialAccount;
+import juby.invest.member.enums.Role;
+import juby.invest.member.repository.MemberRepository;
+import juby.invest.member.repository.SocialAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
+
+    /***
+     * Resource Server로 부터 받은 userRequest를 OAuth2Response DTO로 변환,
+     * 얻은 회원 정보를 DB에 저장하는 함수.
+     * @param userRequest AccessToken과 Client 설정 정보
+     * @return OAuth2User
+     * @throws OAuth2AuthenticationException
+     */
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("oAuth2User = {} ", oAuth2User.getAttributes());
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // Returns the identifier for the registration
+        OAuth2Response oAuth2Response;
+
+        if (registrationId.equals("google")){
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        }
+        else if (registrationId.equals("naver")){
+            oAuth2Response = new NaverResponse(oAuth2User.getAttribute("response"));
+        }
+        else {
+            throw new OAuth2AuthenticationException("해당 provider는 존재하지 않습니다." + registrationId);
+        }
+
+        Member member = memberRepository.findByEmail(oAuth2Response.getEmail());
+
+        // 첫 회원 가입의 경우 (DB에 해당 회원의 이메일이 존재하지 않을 경우)
+        if(member == null){
+            log.info("첫 회원 가입 성공!");
+            Member newMember = memberRepository.save(Member.builder()
+                    .birth(oAuth2Response.getBirthday())
+                    .email(oAuth2Response.getEmail())
+                    .nickName(oAuth2Response.getName())
+                    .profileImg(oAuth2Response.getProfileUrl())
+                    .role(Role.USER)
+                    .build());
+            socialAccountRepository.save(SocialAccount.builder()
+                    .member(newMember)
+                    .provider(oAuth2Response.getProvider())
+                    .provider_id(oAuth2Response.getProviderId())
+                    .build());
+        }
+        else { // DB에 이미 해당 회원의 이메일이 존재할 경우
+            // 기존과 다른 소셜로그인을 통해 로그인 했을 경우
+            if (!socialAccountRepository.existsByMemberAndProvider(member, oAuth2Response.getProvider())){
+                log.info("이미 해당 이메일이 존재하기에 Social Account에 provider와 providerId를 추가합니다.");
+                socialAccountRepository.save(SocialAccount.builder()
+                        .member(member)
+                        .provider(oAuth2Response.getProvider())
+                        .provider_id(oAuth2Response.getProviderId())
+                        .build());
+            }
+            else{
+                log.info("이미 해당 이메일과 해당 provider, providerId가 존재합니다.");
+            }
+        }
+
+        return oAuth2User;
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <button>네이버 로그인</button>
+    <a href="/oauth2/authorization/naver">네이버 로그인</a>
+
+    <button>구글 로그인</button>
+    <a href="/oauth2/authorization/google">구글 로그인</a>
+
+    <button>카카오 로그인</button>
+    <a href="/oauth/authorization/kakao">카카오 로그인</a>
+</body>
+</html>


### PR DESCRIPTION
### 💡Related Issue
#16 

### 📌Discription
Google, Naver 소셜로그인을 통해 응답 받은 회원 정보를 `Member`, `SocialAccount` 엔티티에 저장하는 로직을 구현하였습니다.

### 🔨Tasks
- [x] `OAuth2Response`: 인터페이스를 통해 google, naver에서 받은 응답을 통일하는 DTO 클래스를 만들었습니다.
- [x] `CustomeOAuth2MemberService`: `super.loadUser(userRequest)`를 통해서 사용자 정보를 받아오고 DTO 형태로 변환하여 db에 저장합니다.