### PR TITLE
♻️Refactor: API 응답 통일에 따른 백테스트 로직 수정

### DIFF
--- a/src/main/java/juby/invest/domain/backtest/controller/BacktestController.java
+++ b/src/main/java/juby/invest/domain/backtest/controller/BacktestController.java
@@ -1,9 +1,9 @@
 package juby.invest.domain.backtest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import juby.invest.domain.backtest.dto.BacktestResDTO;
+import juby.invest.domain.backtest.dto.BacktestReqDto;
+import juby.invest.domain.backtest.dto.BacktestResDto;
 import juby.invest.domain.backtest.exception.code.BacktestSuccessCode;
 import juby.invest.domain.backtest.service.BacktestService;
 import juby.invest.domain.member.dto.CustomOAuth2User;
@@ -12,10 +12,7 @@ import juby.invest.global.apiPayload.code.BaseSuccessCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/backtest")
@@ -28,19 +25,16 @@ public class BacktestController {
 
     /***
      *
-     * @param stockCode
-     * @param strategyName
      * @return
      */
     @Operation(summary = "백테스트 실행", description = "종목 코드와 전략 번호를 전달해주면 해당 전략을 실행한다.")
-    @GetMapping("/run")
-    public ApiResponse<BacktestResDTO.GetInfo> convert(
+    @PostMapping("/run")
+    public ApiResponse<BacktestResDto.GetInfo> convert(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @Parameter(description = "종목 코드") @RequestParam("stock_code") String stockCode,
-            @Parameter(description = "전략 이름 (예) smaStrategy)") @RequestParam("strategy_name") String strategyName){
+            @RequestBody BacktestReqDto.ReqInfo dto){
 
         BaseSuccessCode successCode = BacktestSuccessCode.OK;
         log.info(customOAuth2User.getName());
-        return ApiResponse.onSuccess(successCode, backtestService.runStrategy(stockCode, strategyName));
+        return ApiResponse.onSuccess(successCode, backtestService.runStrategy(dto));
     }
 }

--- a/src/main/java/juby/invest/domain/backtest/dto/BacktestReqDto.java
+++ b/src/main/java/juby/invest/domain/backtest/dto/BacktestReqDto.java
@@ -1,0 +1,19 @@
+package juby.invest.domain.backtest.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class BacktestReqDto {
+
+    @Builder
+    public record ReqInfo(
+            String stockCode,
+            String strategyName,
+            LocalDate startDate,
+            LocalDate endDate
+    ){}
+}

--- a/src/main/java/juby/invest/domain/backtest/dto/BacktestResDto.java
+++ b/src/main/java/juby/invest/domain/backtest/dto/BacktestResDto.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import java.math.BigDecimal;
 
 @Builder
-public class BacktestResDTO {
+public class BacktestResDto {
 
     @Builder
     public record GetInfo(

--- a/src/main/java/juby/invest/domain/backtest/service/BacktestService.java
+++ b/src/main/java/juby/invest/domain/backtest/service/BacktestService.java
@@ -1,13 +1,14 @@
 package juby.invest.domain.backtest.service;
 
 import jakarta.transaction.Transactional;
+import juby.invest.domain.backtest.dto.BacktestReqDto;
 import juby.invest.domain.backtest.exception.BacktestException;
 import juby.invest.domain.backtest.exception.code.BacktestErrorCode;
 import juby.invest.domain.stock.entity.DailyPrice;
 import juby.invest.domain.stock.repository.DailyPriceRepository;
 import juby.invest.domain.backtest.converter.AnalysisCriterionConverter;
 import juby.invest.domain.backtest.converter.BarSeriesConverter;
-import juby.invest.domain.backtest.dto.BacktestResDTO;
+import juby.invest.domain.backtest.dto.BacktestResDto;
 import juby.invest.domain.backtest.strategy.BacktestStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.backtest.BarSeriesManager;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -32,14 +34,20 @@ public class BacktestService {
     private final Map<String, BacktestStrategy> strategyMap;
 
     /***
-     * 함수: 종목코드와 전략 이름을 바탕으로 전략을 실행한다.
-     * @param stockCode 종목 코드 (ex 005930)
+     * 전달받은 종목코드, 전략, 시작일, 종료일을 기준으로 백테스트 전략을 수행한다.
+     * @param dto BacktestReqDto.ReqInfo
+     * @return BacktestResDto.GetInfo
      */
     @Transactional
-    public BacktestResDTO.GetInfo runStrategy(String stockCode, String strategyName){
+    public BacktestResDto.GetInfo runStrategy(BacktestReqDto.ReqInfo dto){
+
+        String stockCode = dto.stockCode();
+        String strategyName = dto.strategyName();
+        LocalDate startDate = dto.startDate();
+        LocalDate endDate = dto.endDate();
 
         // List<DailyPrice -> ta4j의 Barseries 변환
-        List<DailyPrice> dailyPriceList = dailyPriceRepository.findByStockStockCodeOrderByDateAsc(stockCode);
+        List<DailyPrice> dailyPriceList = dailyPriceRepository.findByStock_StockCodeAndDateBetweenOrderByDateAsc(stockCode, startDate, endDate);
 
         if (dailyPriceList.isEmpty()){
             throw new BacktestException(BacktestErrorCode.STOCKCODE_NOT_FOUND);
@@ -64,7 +72,7 @@ public class BacktestService {
         // 결과 지표 분석
         List<BigDecimal> analysisList = analysisCriterionConverter.converter(series, record);
 
-        return BacktestResDTO.GetInfo.builder()
+        return BacktestResDto.GetInfo.builder()
                 .stockCode(stockCode)
                 .strategyName(strategy.getName())
                 .totalReturn(analysisList.get(0))

--- a/src/main/java/juby/invest/domain/stock/repository/DailyPriceRepository.java
+++ b/src/main/java/juby/invest/domain/stock/repository/DailyPriceRepository.java
@@ -3,13 +3,24 @@ package juby.invest.domain.stock.repository;
 import juby.invest.domain.stock.entity.DailyPrice;
 import juby.invest.domain.stock.entity.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface DailyPriceRepository extends JpaRepository<DailyPrice, Long> {
+
     boolean existsByStock(Stock stock);
 
-    List<DailyPrice> findByStockStockCodeOrderByDateAsc(String stockCode);
+    List<DailyPrice> findByStock_StockCodeOrderByDateAsc(String stockCode);
+
+    List<DailyPrice> findByStock_StockCodeAndDateBetweenOrderByDateAsc(
+            String stockCode,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
+    String stock(Stock stock);
 }


### PR DESCRIPTION
### 💡Related Issue
#29 
#15 

### 📌Discription
API 응답 통일에 따라서 백테스트 로직을 수정하였습니다.

### 🔨Tasks
- [x] `BacktestReqDto`: Dto 객체를 만들어 전략, 종목코드, 투자기간 파라미터가 입력으로 들어오게끔 하였습니다.
- [x] `BacktestService`: Dto 객체를 받아 거기서 DB를 통해 해당 파라미터에 맞는 `DailyPrice` 리스트를 반환합니다.
- [x] `BacktestController`: 기존 `@RequestParam` -> `@RequestBody`로 수정하였습니다.