### PR TITLE
🌟Feature/32 네이버 뉴스 검색 API 호출 기능 구현

### DIFF
--- a/src/main/java/juby/invest/domain/news/controller/NewsController.java
+++ b/src/main/java/juby/invest/domain/news/controller/NewsController.java
@@ -1,0 +1,27 @@
+package juby.invest.domain.news.controller;
+
+import juby.invest.domain.news.dto.NewsResDto;
+import juby.invest.domain.news.exception.code.NewsSuccessCode;
+import juby.invest.domain.news.service.NewsService;
+import juby.invest.global.apiPayload.ApiResponse;
+import juby.invest.global.apiPayload.code.BaseSuccessCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/v1/news")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @GetMapping
+    public ApiResponse<NewsResDto.NewsResponse> searchNews(
+            @RequestParam("query") String query
+            ){
+        BaseSuccessCode successCode = NewsSuccessCode.OK;
+        return ApiResponse.onSuccess(successCode, newsService.callNewsApi(query));
+    }
+}

--- a/src/main/java/juby/invest/domain/news/dto/NewsReqDto.java
+++ b/src/main/java/juby/invest/domain/news/dto/NewsReqDto.java
@@ -1,0 +1,4 @@
+package juby.invest.domain.news.dto;
+
+public class NewsReqDto {
+}

--- a/src/main/java/juby/invest/domain/news/dto/NewsResDto.java
+++ b/src/main/java/juby/invest/domain/news/dto/NewsResDto.java
@@ -1,0 +1,27 @@
+package juby.invest.domain.news.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class NewsResDto {
+
+    @Builder
+    public record NewsResponse(
+          @JsonProperty("display")
+          Integer display,
+
+          @JsonProperty("items")
+          List<ItemDetail> itemList
+    ){}
+
+    @Builder
+    public record ItemDetail(
+            String title,
+            String originallink,
+            String description,
+            String pubDate
+    ){}
+}

--- a/src/main/java/juby/invest/domain/news/exception/NewsException.java
+++ b/src/main/java/juby/invest/domain/news/exception/NewsException.java
@@ -1,0 +1,10 @@
+package juby.invest.domain.news.exception;
+
+import juby.invest.global.apiPayload.code.BaseErrorCode;
+import juby.invest.global.apiPayload.exception.ProjectException;
+
+public class NewsException extends ProjectException {
+    public NewsException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/juby/invest/domain/news/exception/code/NewsErrorCode.java
+++ b/src/main/java/juby/invest/domain/news/exception/code/NewsErrorCode.java
@@ -1,0 +1,17 @@
+package juby.invest.domain.news.exception.code;
+
+import juby.invest.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NewsErrorCode implements BaseErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NEWS404_1", "네이버 뉴스 API 요청을 실패하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/juby/invest/domain/news/exception/code/NewsSuccessCode.java
+++ b/src/main/java/juby/invest/domain/news/exception/code/NewsSuccessCode.java
@@ -1,0 +1,18 @@
+package juby.invest.domain.news.exception.code;
+
+import juby.invest.global.apiPayload.code.BaseErrorCode;
+import juby.invest.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum NewsSuccessCode implements BaseSuccessCode {
+
+    OK(HttpStatus.OK, "네이버 뉴스 검색 API 요청에 성공했습니다.", "NEWS200_1");
+
+    private final HttpStatus status;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/juby/invest/domain/news/service/NewsService.java
+++ b/src/main/java/juby/invest/domain/news/service/NewsService.java
@@ -1,0 +1,55 @@
+package juby.invest.domain.news.service;
+
+import juby.invest.domain.news.dto.NewsResDto;
+import juby.invest.domain.news.exception.NewsException;
+import juby.invest.domain.news.exception.code.NewsErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final RestClient newsSearchRestClient;
+
+    public NewsResDto.NewsResponse callNewsApi(String query){
+
+        NewsResDto.NewsResponse response = newsSearchRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("query", query)
+                        .build())
+                .retrieve()
+                .body(NewsResDto.NewsResponse.class);
+
+        if (response == null){
+            throw new NewsException(NewsErrorCode.NOT_FOUND);
+        }
+
+        return cleanHtml(response);
+    }
+
+    public NewsResDto.NewsResponse cleanHtml(NewsResDto.NewsResponse response){
+        List<NewsResDto.ItemDetail> cleanedItemList = response.itemList().stream()
+                .map(item -> NewsResDto.ItemDetail.builder()
+                        .title(cleanHtml(item.title()))
+                        .originallink(item.originallink())
+                        .description(cleanHtml(item.description()))
+                        .pubDate(item.pubDate())
+                        .build())
+                .toList();
+
+        return NewsResDto.NewsResponse.builder()
+                .display(response.display())
+                .itemList(cleanedItemList)
+                .build();
+    }
+
+    private String cleanHtml(String html){
+        String noTag = html.replaceAll("<[^>]*>", "");
+        return HtmlUtils.htmlUnescape(noTag);
+    }
+}

--- a/src/main/java/juby/invest/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/juby/invest/global/apiPayload/code/GeneralSuccessCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum GeneralSuccessCode implements BaseErrorCode{
+public enum GeneralSuccessCode implements BaseSuccessCode{
 
     OK(HttpStatus.OK,
             "COMMON200_1",

--- a/src/main/java/juby/invest/global/config/AppConfig.java
+++ b/src/main/java/juby/invest/global/config/AppConfig.java
@@ -10,6 +10,9 @@ public class AppConfig {
 
     @Value("${kis.mock.base-url}") private String mockInvestUrl;
     @Value("${kis.real.base-url}") private String realInvestUrl;
+    @Value("${naver.news.base-url}") private String naverNewsSearchUrl;
+    @Value("${naver.news.app-key}") private String naverNewsAppKey;
+    @Value("${naver.news.app-secret}") private String naverNewsAppSecret;
 
     // 모의 Domain
     @Bean
@@ -24,6 +27,16 @@ public class AppConfig {
     public RestClient realInvestRestClient(){
         return RestClient.builder()
                 .baseUrl(realInvestUrl)
+                .build();
+    }
+
+    // 네이버 뉴스 검색 API
+    @Bean
+    public RestClient newsSearchRestClient(){
+        return RestClient.builder()
+                .baseUrl(naverNewsSearchUrl)
+                .defaultHeader("X-Naver-Client-Id", naverNewsAppKey)
+                .defaultHeader("X-Naver-Client-Secret", naverNewsAppSecret)
                 .build();
     }
 }

--- a/src/main/java/juby/invest/global/config/SecurityConfig.java
+++ b/src/main/java/juby/invest/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**", "/swagger-ui/**", "/v3/api-docs/**", "/error/**").permitAll()
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/swagger-ui/**", "/v3/api-docs/**", "/error/**",
+                                "/v1/**", "/api/**").permitAll() // 나중에는 v1, api 삭제해야함.
                         .anyRequest().authenticated());
 
         http

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,6 +58,12 @@ kis:
     app-key: ${KIS_REALAPPKEY}
     app-secret: ${KIS_REALAPPSECRET}
 
+naver:
+  news:
+    base-url: "https://openapi.naver.com/v1/search/news.json"
+    app-key: ${NAVER_CLIENT_ID}
+    app-secret: ${NAVER_CLIENT_SECRET}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 1800000 # 30분


### PR DESCRIPTION
### 💡Related Issue
#32 

### 📌Discription
네이버 뉴스 검색 API 호출 기능을 구현하였습니다. 추가로 응답의 title과 description 본문에 html 태그와 & 기호가 포함되어있어, 받은 응답을 제거하는 로직을 구현하였습니다.

### 🔨 Tasks
- [x] `AppConfig`: 요청 URL과 기본 헤더 정보들을 포함합니다.
- [x] `application.yaml`: client-id, secret 환경변수를 추가하였습니다.
- [x] `NewsResponse Dto`: 요청 응답을 받을 DTO 클래스입니다.
- [x] `NewsService`: API를 호출하는 로직, html 태그와 & 기호를 제거하는 로직입니다. 제거 후에 컨트롤러 계층으로 넘겨줍니다.
- [x] `NewsController`: `GET /v1/news`를 통해 요청을 받습니다. 파라미터로 ?query=검색을 받습니다.
- [x] `NewsSuccessCode`: 성공 응답 200
- [x] `NewsErrorCode`: 실패 응답 NOT_FOUND 404