### PR TITLE
🌟[Feature/41]: 토큰 만료 로컬/개발서버 동기화

### DIFF
--- a/src/main/java/juby/invest/domain/kis/token/entity/KisToken.java
+++ b/src/main/java/juby/invest/domain/kis/token/entity/KisToken.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Entity
@@ -31,9 +32,9 @@ public class KisToken {
     private String tokenValue;
 
     @Column(name = "expired_at", nullable = false)
-    private LocalDateTime expiredAt;
+    private Instant expiredAt;
 
-    public void updateToken(String updateToken, LocalDateTime updateExpiredAt) {
+    public void updateToken(String updateToken, Instant updateExpiredAt) {
         this.tokenValue = updateToken;
         this.expiredAt = updateExpiredAt;
     }

--- a/src/main/java/juby/invest/domain/kis/token/service/TokenService.java
+++ b/src/main/java/juby/invest/domain/kis/token/service/TokenService.java
@@ -3,8 +3,6 @@ package juby.invest.domain.kis.token.service;
 import juby.invest.domain.kis.token.dto.TokenDto;
 import juby.invest.domain.kis.token.entity.KisToken;
 import juby.invest.domain.kis.token.enums.TokenType;
-import juby.invest.domain.kis.token.exception.TokenException;
-import juby.invest.domain.kis.token.exception.code.TokenErrorCode;
 import juby.invest.domain.kis.token.repository.TokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +10,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
@@ -71,13 +73,13 @@ public class TokenService {
             if (optionalKisToken.isPresent()) {
                 log.info("기존 {} 토큰이 최신화됩니다. 토큰 값: {}", tokenType, response.accessToken());
                 KisToken kisToken = optionalKisToken.get();
-                kisToken.updateToken(response.accessToken(), stringToLocalDateTime(response.expiresAt()));
+                kisToken.updateToken(response.accessToken(), stringToInstantTime(response.expiresAt()));
             } else { // 토큰이 아예 없는 경우 -> save
                 log.info("새로 {} 토큰이 발급됩니다. 토큰 값: {}", tokenType, response.accessToken());
                 KisToken kisToken = KisToken.builder()
                         .tokenType(tokenType)
                         .tokenValue(response.accessToken())
-                        .expiredAt(stringToLocalDateTime(response.expiresAt()))
+                        .expiredAt(stringToInstantTime(response.expiresAt()))
                         .build();
 
                 tokenRepository.save(kisToken);
@@ -117,7 +119,7 @@ public class TokenService {
      */
     private boolean isValid(KisToken kisToken) {
         // 현재 시간 + 10분이 토큰의 유효시간보다 이전이어야 한다.
-        LocalDateTime nowPlus10Min = LocalDateTime.now().plusMinutes(10);
+        Instant nowPlus10Min = Instant.now().plus(Duration.ofMinutes(10));
 
         return nowPlus10Min.isBefore(kisToken.getExpiredAt());
     }
@@ -125,12 +127,12 @@ public class TokenService {
     /***
      * String -> LocalDateTime으로 변환하는 함수
      * @param dateStr KIS 토큰 발급 API 응답값
-     * @return 만료시간 (localDateTime)
+     * @return 만료시간 (Instant)
      */
-    private LocalDateTime stringToLocalDateTime(String dateStr) {
+    private Instant stringToInstantTime(String dateStr) {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-        return LocalDateTime.parse(dateStr, formatter);
+        LocalDateTime localDateTime = LocalDateTime.parse(dateStr, formatter);
+        return localDateTime.atZone(ZoneId.of("Asia/Seoul")).toInstant();
     }
 }


### PR DESCRIPTION


## 🔗 Related Issue
> 아래에 연관된 이슈 번호를 적어주세요.
#41 

## 📝 Summary
> 작업한 내용에 대해 간략적으로 설명해주세요.
현재 로컬 서버(KST)와 개발 서버(UTC)의 표준시 다릅니다. 따라서 토큰 만료 시간을 DB에 저장할 때 UTC로 통일을 하고, `isValid` 함수도 UTC 기준으로 측정합니다.

## 🔄 Changes
> 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요
- [x] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [ ] 설정 또는 인프라 관련 변경
- [ ] 리팩토링