### PR TITLE
♻️[Fix/41]: KIS API 초당 횟수 제한 고려

### DIFF
--- a/src/main/java/juby/invest/domain/kis/market/scheduler/DailyPriceScheduler.java
+++ b/src/main/java/juby/invest/domain/kis/market/scheduler/DailyPriceScheduler.java
@@ -31,7 +31,7 @@ public class DailyPriceScheduler {
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     @Profile("dev") // EC2에서만 실행
-    @Scheduled(cron = "0 35 15 * * MON-FRI", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 5 21 * * MON-FRI", zone = "Asia/Seoul")
     public void getDailyPrice() throws InterruptedException {
 
         // 장날/휴장일인지 먼저 파악
@@ -74,7 +74,7 @@ public class DailyPriceScheduler {
             } catch (Exception e) {
                 log.error("스케줄러 동작 중 문제 발생: {}, 종목명: {}", e, stock.getStockName());
             }
-            Thread.sleep(100); // 실전 도메인 API 호출 제한: 1초당 18건
+            Thread.sleep(200); // 실전 도메인 API 호출 제한: 1초당 18건
         }
 
         if (!dailyPrices.isEmpty()){


### PR DESCRIPTION


## 🔗 Related Issue
> 아래에 연관된 이슈 번호를 적어주세요.
#41 

## 📝 Summary
> 작업한 내용에 대해 간략적으로 설명해주세요.
KIS API 초당 호출 횟수 고려하여 Thread.sleep(100) -> 200으로 늘렸습니다.

## 🔄 Changes
> 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요
- [x] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [ ] 설정 또는 인프라 관련 변경
- [ ] 리팩토링